### PR TITLE
Update Description of Options Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ ardoq.analytics-clj> (identify client "user-id" {:email "test@example.org"})
 
 ardoq.analytics-clj> (track client "user-id" "Logged in" {:plan {:type "trial" :started (DateTime.)}})
 
-;;You can also use options like :contet, timestamp and a callback function. See api for details
+;;You can also pass an additional map containing :options, :timestamp and :callback keys. See api for details
 ardoq.analytics-clj> (track client "user-id" "Played song" {:title "My title"} 
-                         {:context {:ip "10.0.0.1"} 
+                         {:options {:ip "10.0.0.1"} 
                           :callback (fn [s m] (println "\n\nDONE!"))})
 
 ardoq.analytics-clj> (make-alias client "user-id" "real-id")


### PR DESCRIPTION
According to the [source](https://github.com/ardoq/analytics-clj/blob/master/src/ardoq/analytics_clj.clj#L79), the `:context` key should actually be `:options` (although `:context` would more accurately reflect the concept of a Segment [special context](https://segment.com/docs/api/tracking/track/#special-context))

I don't feel too strongly about the name, but figured it was best for the README to be accurate for now. Thanks for the great library!
